### PR TITLE
Use THINK_TIME when starting thinker

### DIFF
--- a/scripts/vscripts/barebones.lua
+++ b/scripts/vscripts/barebones.lua
@@ -134,7 +134,7 @@ function BareBonesGameMode:CaptureGameMode()
     GameRules:SetHeroMinimapIconSize( 300 )
 
     print( '[BAREBONES] Beginning Think' ) 
-    GameMode:SetContextThink("BarebonesThink", Dynamic_Wrap( BareBonesGameMode, 'Think' ), 0.1 )
+    GameMode:SetContextThink("BarebonesThink", Dynamic_Wrap( BareBonesGameMode, 'Think' ), THINK_TIME )
   end 
 end
 


### PR DESCRIPTION
Is there any reason that you are starting it with 0.1 instead of THINK_TIME?
