### PR TITLE
add smart defaults for UnitTest

### DIFF
--- a/ProjectilesChangeLog.md
+++ b/ProjectilesChangeLog.md
@@ -1,5 +1,8 @@
 # projectiles.lua ChangeLog
 
+### Version 0.84
+- Added smart default behavior for UnitTest
+
 ### Version 0.83
 - Added additional guards to better handle 'script_reload' 
 

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -80,6 +80,7 @@ Projectiles are effectively a formatted lua table which is registered with the P
 | iVisionTeamNumber | &lt;Source unit's team&gt; | The team for which to display this projectile's vision if enabled.|
 | nChangeMax | 1 | The maximum number of velocity/position changes this particle can undergo before it stops allowing changing position/velocity. |
 | Source | &lt;none&gt; | The source unit of this projectile |
+| ability | &lt;none&gt; | The ability associated with this projectile |
 | TreeBehavior | PROJECTILES_DESTROY | The behavior that the particle should exhibit when colliding with a tree.  PROJECTILES_NOTHING means to do nothing to the projectile.  PROJECTILES_DESTROY means to destroy this projectile.|
 | UnitBehavior | PROJECTILES_DESTROY | The behavior that the particle should exhibit when colliding with a unit which passes the UnitTest function.  PROJECTILES_NOTHING means to do nothing to the projectile.  PROJECTILES_DESTROY means to destroy this projectile.|
 | vSpawnOrigin | Vector(0,0,0) | The initial spawn world position of this projectile. Can be specified in a table form to fire from the attachment point of a unit. Ex: {unit=unitHandle, attach="attach_attack1"[, offset=Vector(0,0,80)]}|

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -15,7 +15,7 @@
 **Projectiles Library Functions**
 =============================
 ####**Projectiles:CreateProjectile(projectile)**
-  This function is used to create ane release the projectile defined by the projectile table passed to the function.  The function returns an updated reference to the projectile table on which the Proejctile Table Functions can be called.  See the Projectiles Table Format section for more detail on what properties can be used with the projectile table.
+  This function is used to create ane release the projectile defined by the projectile table passed to the function.  The function returns an updated reference to the projectile table on which the Projectile Table Functions can be called.  See the Projectiles Table Format section for more detail on what properties can be used with the projectile table.
 
 
 ####**Projectiles:CalcSlope(pos, unit, dir)**

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -25,7 +25,7 @@
   This function can be used to get the estimated normal Vector of the ground at the world point Vector 'pos'.  The 'unit' parameter is used to specify what unit should be used with GetGroundPosition() in order to handle the ground collision sizing.  This function can return odd values when used around sheer vertical edges.
 
 ####**Projectiles:DefaultUnitTest(unit)**
-  This is the default UnitTest function used if none is provided. This test will use the iUnitTargetTeam, iUnitTargetType, and iUnitTargetFlags keys on the projectile, if they're specified. Otherwise, it inherits targeting rules from the ability referenced by the ability key on the projectile. If none of these keys are available, the test will simply always fail.
+  This is the default UnitTest function used if none is provided. This test will use the iUnitTargetTeam, iUnitTargetType, and iUnitTargetFlags keys on the projectile, if they're specified. Otherwise, it inherits targeting rules from the ability referenced by the Ability key on the projectile. If none of these keys are available, the test will simply always fail.
   
 
 **Projectile Table Functions**

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -48,7 +48,7 @@ Projectiles are effectively a formatted lua table which is registered with the P
 
 | Property  | Default | Description |
 | :------------ | :--------| :-----|
-| ability | &lt;none&gt; | The ability associated with this projectile |
+| Ability | &lt;none&gt; | The ability associated with this projectile |
 | bProvidesVision | false | If set to true, this projectile will provide vision around it as it travels. |
 | bCutTrees | false | If set to true, this projectile will cut any trees that it comes in contact with. |
 | bFlyingVision | true | If set to true and, this projectile will provide flying vision as it travels (if bProvidesVision is enabled) |

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -24,6 +24,9 @@
 ####**Projectiles:CalcNormal(pos, unit, scale)**
   This function can be used to get the estimated normal Vector of the ground at the world point Vector 'pos'.  The 'unit' parameter is used to specify what unit should be used with GetGroundPosition() in order to handle the ground collision sizing.  This function can return odd values when used around sheer vertical edges.
 
+####**Projectiles:DefaultUnitTest(unit)**
+  This is the default UnitTest function used if none is provided. This test will use the iUnitTargetTeam, iUnitTargetType, and iUnitTargetFlags keys on the projectile, if they're specified. Otherwise, it inherits targeting rules from the ability referenced by the ability key on the projectile. If none of these keys are available, the test will simply always fail.
+  
 
 **Projectile Table Functions**
 =============================

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -48,6 +48,7 @@ Projectiles are effectively a formatted lua table which is registered with the P
 
 | Property  | Default | Description |
 | :------------ | :--------| :-----|
+| ability | &lt;none&gt; | The ability associated with this projectile |
 | bProvidesVision | false | If set to true, this projectile will provide vision around it as it travels. |
 | bCutTrees | false | If set to true, this projectile will cut any trees that it comes in contact with. |
 | bFlyingVision | true | If set to true and, this projectile will provide flying vision as it travels (if bProvidesVision is enabled) |
@@ -80,7 +81,6 @@ Projectiles are effectively a formatted lua table which is registered with the P
 | iVisionTeamNumber | &lt;Source unit's team&gt; | The team for which to display this projectile's vision if enabled.|
 | nChangeMax | 1 | The maximum number of velocity/position changes this particle can undergo before it stops allowing changing position/velocity. |
 | Source | &lt;none&gt; | The source unit of this projectile |
-| ability | &lt;none&gt; | The ability associated with this projectile |
 | TreeBehavior | PROJECTILES_DESTROY | The behavior that the particle should exhibit when colliding with a tree.  PROJECTILES_NOTHING means to do nothing to the projectile.  PROJECTILES_DESTROY means to destroy this projectile.|
 | UnitBehavior | PROJECTILES_DESTROY | The behavior that the particle should exhibit when colliding with a unit which passes the UnitTest function.  PROJECTILES_NOTHING means to do nothing to the projectile.  PROJECTILES_DESTROY means to destroy this projectile.|
 | vSpawnOrigin | Vector(0,0,0) | The initial spawn world position of this projectile. Can be specified in a table form to fire from the attachment point of a unit. Ex: {unit=unitHandle, attach="attach_attack1"[, offset=Vector(0,0,80)]}|

--- a/game/dota_addons/barebones/scripts/vscripts/libraries/projectiles.lua
+++ b/game/dota_addons/barebones/scripts/vscripts/libraries/projectiles.lua
@@ -104,8 +104,8 @@ function Projectiles:DefaultUnitTest(unit)
     if source then
         if self.iUnitTargetTeam or self.iUnitTargetFlags or self.iUnitTargetType then
             return 0 == UnitFilter(unit, self.iUnitTargetTeam or 0, self.iUnitTargetType or 0, self.iUnitTargetFlags or 0, source:GetTeam())
-        elseif self.ability then
-            return 0 == UnitFilter(unit, self.ability:GetAbilityTargetTeam(), self.ability:GetAbilityTargetType(), self.ability:GetAbilityTargetFlags(), source:GetTeam())
+        elseif self.Ability then
+            return 0 == UnitFilter(unit, self.Ability:GetAbilityTargetTeam(), self.Ability:GetAbilityTargetType(), self.Ability:GetAbilityTargetFlags(), source:GetTeam())
         end
     end
     return false
@@ -181,8 +181,8 @@ function Projectiles:CreateProjectile(projectile)
     projectile.vSpawnOrigin = projectile.vSpawnOrigin or Vector(0,0,0)
   end
 
-  if projectile.ability then
-    projectile.caster = projectile.ability:GetCaster()
+  if projectile.Ability then
+    projectile.caster = projectile.Ability:GetCaster()
   end
   projectile.rehit = {}
   projectile.pos = projectile.vSpawnOrigin


### PR DESCRIPTION
makes the default UnitTest check for keys on the projectile table to determine targeting. also adds an Ability key that can be used to inherit targeting rules from an ability.
