### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CollidersReadme.md
+++ b/CollidersReadme.md
@@ -1,12 +1,12 @@
-#**BMD's Lua Unit Colliders Library**
+# **BMD's Lua Unit Colliders Library**
 --------------------------------
 See [PhysicsReadme.md](https://github.com/bmddota/barebones/blob/source2/PhysicsReadme.md) for documentation and examples on using Physics/Motion controls.
 
-####**How to install:**
+#### **How to install:**
 - Drop physics.lua in with your vscripts
 - Add require( 'physics' ) somewhere in your lua instantiation path
 
-####**How to use:**
+#### **How to use:**
 - The colliders system can operate on regular units and Physics-units (though can only operate on Physics-units in some noted cases)
 - Colliders are constructed out of collider tables, of which several profiles are provided with this library (and more can be created)
 - Colliders are one of 3 primary types, COLLIDER_SPHERE, COLLIDER_BOX, or COLLIDER_AABOX
@@ -19,16 +19,16 @@ See [PhysicsReadme.md](https://github.com/bmddota/barebones/blob/source2/Physics
 
 **Colliders Library Functions**
 =============================
-####**Physics:AddCollider([name,] collider)**
+#### **Physics:AddCollider([name,] collider)**
   This function is used for creating a collider without a profile without being tied to any particular unit.  The "name" parameter is optional, but must be unique if given.  Collider follows the standard collider format as given in the Collider Format section.  Returns the registered collider for additional modification/reference.
 
-####**Physics:ColliderFromProfile(profileName[, collider])**
+#### **Physics:ColliderFromProfile(profileName[, collider])**
   This function is used to create a new collider from the given collider profile name.  The profile name must match a registered profile.  Returns a copy of the collider profile modified with the properties passed in for the 'collider' table if given.
 
-####**Physics:CreateColliderProfile(profileName, profile)**
+#### **Physics:CreateColliderProfile(profileName, profile)**
   This function is used to create and register a new collider profile for the given profile name.  This registered collider profile can then be used to create new colliders using the profile collider table as a base.
 
-####**Physics:RemoveCollider(name)**
+#### **Physics:RemoveCollider(name)**
   This function removes a collider by name from the Physics API so that it is no longer processed.
 
 
@@ -36,22 +36,22 @@ See [PhysicsReadme.md](https://github.com/bmddota/barebones/blob/source2/Physics
 =============================
 A unit which has been converted to a Physics Unit can have a collider attached to it and managed using the following functions:
 
-####**AddCollider([name,] collider)**
+#### **AddCollider([name,] collider)**
   This function can be called to add a collider (in the correct Collider Format) to the unit.  An optional name can be given, or a unique name will be used.  The resulting collider will be returned for further adjustment/management.
 
-####**AddColliderFromProfile([name,] profile, [collider])**
+#### **AddColliderFromProfile([name,] profile, [collider])**
   This function can be called to add a collider from a registered collider profile to this unit.  The profile must be provided, as can an optional name or collider properties table.  The resulting collider will be returned for further adjustment/management.
 
-####**GetColliders()**
+#### **GetColliders()**
   Returns a table of all colliders attached to this unit in {name=colliderTable} format.
 
-####**GetMass()**
+#### **GetMass()**
   Returns the mass of this unit for use in "momentum" collider calculations.  The default mass is set to 100.
 
-####**RemoveCollider(name)**
+#### **RemoveCollider(name)**
   This function can be called to remove a collider by name from this unit.  The collider will also be removed from the Physics API.
 
-####**SetMass(mass)**
+#### **SetMass(mass)**
   Sets the mass of this unit for use in "momentum" collider calculations.
 
 
@@ -60,7 +60,7 @@ A unit which has been converted to a Physics Unit can have a collider attached t
 =============================
 Colliders are effectively a formatted lua table which is registered with the Physics API for processing and action.  All collider tables have the following properties and functions, though individual colliders can have additional properties/functions in order to support their actions:
 
-###**COLLIDER_SPHERE Type**
+### **COLLIDER_SPHERE Type**
 | Property  | Description |
 | :------------ | :-----|
 | draw      | Whether to DebugDraw the collider for visual confirmation.  Additionally, a table can be provided with color and alpha properties. | 
@@ -81,7 +81,7 @@ Colliders are effectively a formatted lua table which is registered with the Phy
 | test      | colliderTable, colliderUnit, collidedUnit | Called when a unit is found within the collider range to test for matching the collider criteria.  This function should return true if the collider should interact with the colliding unit, and false if not. |
 
 
-###**COLLIDER_BOX/COLLIDER_AABOX Type**
+### **COLLIDER_BOX/COLLIDER_AABOX Type**
 
 | Property  | Description |
 | :------------ | :-----|
@@ -106,9 +106,9 @@ Colliders are effectively a formatted lua table which is registered with the Phy
 
 **Built-in Collider Profiles**
 =============================
-##**COLLIDER_SPHERE**
+## **COLLIDER_SPHERE**
 
-###**blocker**
+### **blocker**
 A blocker collider blocks out either the colliding unit or the collider-attached unit whenever a successful collision is found.  Can affect non-Physics units.
 
 | Property  | Description |
@@ -118,7 +118,7 @@ A blocker collider blocks out either the colliding unit or the collider-attached
 | moveSelf      | If set to true, this collider will move the attached unit instead of the colliding unit. Defaults to false.| 
 
 
-###**delete**
+### **delete**
 A delete collider deletes the colliding unit or the collider-attached unit whenever a successful collision is found.  Can affect non-Physics units.
 
 | Property  | Description |
@@ -127,7 +127,7 @@ A delete collider deletes the colliding unit or the collider-attached unit whene
 | removeCollider      | When this collider successfully collides with a unit, immediately remove it so as to prevent further collisions.  Defaults to true. | 
 
 
-###**gravity**
+### **gravity**
 A gravity collider applies a force to any colliding unit attracting it towards the collider-attached unit with a given force and function.
 
 | Property  | Description |
@@ -138,7 +138,7 @@ A gravity collider applies a force to any colliding unit attracting it towards t
 | minRadius      | The radius to use for when a colliding unit is too close to the attached unit and should receive 0 gravitational force. An "eye-of-the-storm" radius. Default is 0.|
 
 
-###**repel**
+### **repel**
 A repel collider applies a force to any colliding unit repelling it away from the collider-attached unit with a given force and function.
 
 | Property  | Description |
@@ -149,7 +149,7 @@ A repel collider applies a force to any colliding unit repelling it away from th
 | minRadius      | The radius to use for when a colliding unit is too close to the attached unit and should receive 0 repulsion force. An "eye-of-the-storm" radius. Default is 0.|
 
 
-###**reflect**
+### **reflect**
 A reflect collider applies a reflection force using the incident vector of collision with the collider sphere to redirect the velocity of the colliding unit.  Additionally can act as a blocker.
 
 | Property  | Description |
@@ -162,7 +162,7 @@ A reflect collider applies a reflection force using the incident vector of colli
 | multiplier | The scalar multiplier to apply to the incident vector velocity to create the reflecting force.  Defaults to 1.0|
 
 
-###**momentum**
+### **momentum**
 A momentum collider applies a force to the colliding unit and collider-attached unit in accordance with their mass as set on their Physics Unit settings.  The elasticity coefficient of the collision can be set.  Additionally can act as a blocker.
 
 | Property  | Description |
@@ -174,7 +174,7 @@ A momentum collider applies a force to the colliding unit and collider-attached 
 | findClearSpace      | If blocking, whether to use FindClearSpaceForUnit to block the colliding unit out.  Defaults to false. | 
 | moveSelf      | If blocking and set to true, this collider will move the attached unit instead of the colliding unit. Defaults to false.| 
 
-###**momentumFull**
+### **momentumFull**
 A momentumFull collider applies a force to the colliding unit and collider-attached unit in accordance with their mass as set on their Physics Unit settings.  MomentumFull differs from a standard momentum collider by ensuring that full force is always transferred regardless of the angle.  The elasticity coefficient of the collision can be set.  Additionally can act as a blocker.
 
 | Property  | Description |
@@ -188,9 +188,9 @@ A momentumFull collider applies a force to the colliding unit and collider-attac
 
 
 -----------------------------------
-##**COLLIDER_AABOX / COLLIDER_BOX**
+## **COLLIDER_AABOX / COLLIDER_BOX**
 
-###**aaboxblocker** / **boxblocker**
+### **aaboxblocker** / **boxblocker**
 A boxblocker collider blocks out the colliding unit whenever a successful collision is found.  Can affect non-Physics units if 'slide' property is set to false.
 
 | Property  | Description |
@@ -200,7 +200,7 @@ A boxblocker collider blocks out the colliding unit whenever a successful collis
 | slide      | Whether the colliding Physics Unit should slide along the edge of the box with which it collides. Defaults to true.| 
 
 
-###**aaboxreflect** / **boxreflect**
+### **aaboxreflect** / **boxreflect**
 A boxreflect collider blocks out the colliding unit whenever a successful collision is found.  
 
 | Property  | Description |

--- a/PhysicsReadme.md
+++ b/PhysicsReadme.md
@@ -1,12 +1,12 @@
-#**BMD's Lua Unit Physics Library**
+# **BMD's Lua Unit Physics Library**
 --------------------------------
 See [CollidersReadme.md](https://github.com/bmddota/barebones/blob/source2/CollidersReadme.md) for documentation and examples on using Colliders.
 
-####**How to install:**
+#### **How to install:**
 - Drop physics.lua in with your vscripts
 - Add require( 'physics' ) somewhere in your lua instantiation path
 
-####**How to use:**
+#### **How to use:**
 - To turn any dota unit into a Physics unit, run
   Physics:Unit(unitEntity)
 - This adds a bunch of new functions to the unit which allow for it to simulate physics
@@ -14,164 +14,164 @@ See [CollidersReadme.md](https://github.com/bmddota/barebones/blob/source2/Colli
 
 **Physics Library Functions**
 =============================
-####**Physics:Unit (unit)**
+#### **Physics:Unit (unit)**
   Makes a unit into a "physics" unit which can be manipulated using the PhysicsUnit functions
 
-####**Physics:GenerateAngleGrid()**
+#### **Physics:GenerateAngleGrid()**
   This function is used to generate and apply an angle grid (calculated GNV normal map) for the current map so as to yield better bounces for PHYSICS_NAV_BOUNCE and PHYSICS_NAV_SLIDE collisions.
 
-####**Physics:AngleGrid (anggrid, angoffsets)**
+#### **Physics:AngleGrid (anggrid, angoffsets)**
   This function is an advanced means of setting a normal map for GridNav collisions so as to yield better bounces for PHYSICS_NAV_BOUNCE and PHYSICS_NAV_SLIDE collisions.
 
-####**IsPhysicsUnit (unit)**
+#### **IsPhysicsUnit (unit)**
   This global function returns true if the unit in question has been converted to a "physics" unit.
 
 
 
 **PhysicsUnit Functions:**
 =============================
-####**AdaptiveNavGridLookahead (boolean)**
+#### **AdaptiveNavGridLookahead (boolean)**
   Whether this unit should use an adaptive navgrid lookahead system to more reliably detect GNV collisions at high speed
 
-####**AddPhysicsAcceleration (accelerationVector)**
+#### **AddPhysicsAcceleration (accelerationVector)**
   Adds a new acceleration vector to the current internal acceleration vector.
 
-####**AddPhysicsVelocity (velocityVector)**
+#### **AddPhysicsVelocity (velocityVector)**
   Adds a new velocity vector to the current internal velocity vector.  This is effectively a force push on the unit.
 
-####**AddStaticVelocity (name, velocityVector)**
+#### **AddStaticVelocity (name, velocityVector)**
   Adds a new velocity vector to the current internal static velocity vector of the given name.
 
-####**ClearStaticVelocity ()**
+#### **ClearStaticVelocity ()**
   Clears all current static velocity vectors, effectively setting them to (0,0,0)
 
-####**CutTrees (boolean)**
+#### **CutTrees (boolean)**
   Sets whether this unit should automatically cut trees when it collides with them or not.  Default is false.
 
-####**FollowNavMesh (boolean)**
+#### **FollowNavMesh (boolean)**
   Whether this unit should respect the NavMesh when moving and exhibit NavCollisionType behavior when interacting with a NavGrid block
 
-####**GetAutoUnstuck ()**
+#### **GetAutoUnstuck ()**
   Whether this unit will be returned to its last known good position in the event that it is determined to be stuck in unpathable terrain.  Default is true.
 
-####**GetBounceMultiplier ()**
+#### **GetBounceMultiplier ()**
   Returns the float representing the multiplier to apply to a unit's velocity's magnitude in the event that they bounce via PHYSICS_NAV_BOUNCE.  Default is 1.0 (aka no velocity magnitude change)
 
-####**GetBoundOverride ()**
+#### **GetBoundOverride ()**
   Returns the current boundary radius override for this unit, which will be used when blocking the unit out from navigation grid collisions so that it doesn't get stuck.  Default is the larget value of "unit:GetPaddedCollisionRadius() + 1" or "math.max(unit:GetBoundingMaxs().x, unit:GetBoundingMaxs().y)"
 
-####**GetLastGoodPosition ()**
+#### **GetLastGoodPosition ()**
   Returns the vector position which was the last known position that the unit was in that was unblocked/pathable.
 
-####**GetNavCollisionType ()**
+#### **GetNavCollisionType ()**
   Returns the current GridNav Collision Type (PHYSICS_NAV_NOTHING, PHYSICS_NAV_HALT, PHYSICS_NAV_SLIDE, PHYSICS_NAV_BOUNCE, or PHYSICS_NAV_GROUND)
 
-####**GetNavGridLookahead ()**
+#### **GetNavGridLookahead ()**
   Returns the current number of Navigation Grid lookahead points.  See SetNavGridLookahead for more details. Default is 1
 
-####**GetNavGroundAngle ()**
+#### **GetNavGroundAngle ()**
   Returns the current terrain angle that will cause PHYSICS_NAV_GROUND based navigation to slide.
 
-####**GetPhysicsAcceleration ()**
+#### **GetPhysicsAcceleration ()**
   Returns the current acceleration vector.  Default is (0,0,0)
 
-####**GetPhysicsBoundingRadius ()**
+#### **GetPhysicsBoundingRadius ()**
   Returns the current bounding radius used for navgrid collision.  Default is the PaddedCollisionRadius of a unit.
 
-####**GetPhysicsFlatFriction ()**
+#### **GetPhysicsFlatFriction ()**
   Returns the current flat friction amount.  Default is 0
 
-####**GetPhysicsFriction ()**
+#### **GetPhysicsFriction ()**
   Returns the current friction multiplier and flat friction amount.  Default is .05, 0
 
-####**GetPhysicsVelocity ()**
+#### **GetPhysicsVelocity ()**
   Returns the current velocity vector.  Default is (0,0,0)
 
-####**GetPhysicsVelocityMax ()**
+#### **GetPhysicsVelocityMax ()**
   Returns the maximum velocity.  Default is 0, representing an unlimited velocity
 
-####**GetRebounceFrames ()**
+#### **GetRebounceFrames ()**
   Returns the number of rebounce frames to wait between PHYSICS_NAV_BOUNCE collisions.  Default is 2.
 
-####**GetStaticVelocity (name)**
+#### **GetStaticVelocity (name)**
   Returns the current static velocity force for the given name.
 
-####**GetStuckTimeout ()**
+#### **GetStuckTimeout ()**
   Returns the number of frames necessary to determine if a unit is stuck in unpathable terrain and to activate AutoUnstuck
 
-####**GetSlideMultiplier ()**
+#### **GetSlideMultiplier ()**
   Returns the slide multipler value. Default is 0.1
 
-####**GetTotalVelocity ()**
+#### **GetTotalVelocity ()**
   Returns the unit's total velocity (i.e. Physics velocity + slide velocity + standard right-click movement).  This is nonfunctional while a unit is hibernating, and will return Vector(0,0,0) on the first frame that a Physics unit is created, but a correct value thereafter.
 
-####**GetVelocityClamp ()**
+#### **GetVelocityClamp ()**
   Returns the current velocity clamp in hammer units per second.  Default is 20 hammer units per second
 
-####**Hibernate (boolean)**
+#### **Hibernate (boolean)**
   Whether this unit should Hibernate when there is no sliding/acceleration/velocity.  When hibernating the unit performs no physics calculation until new force/acceleration/sliding is applied.  Additionally, OnPhysicsFrame will not be called if this unit is hibernating.Default is that a unit will hibernate.
 
-####**IsAdaptiveNavGridLookahead ()**
+#### **IsAdaptiveNavGridLookahead ()**
   Returns whether this unit will use an adaptive navgrid lookahead system to more reliably detect GNV collisions at high speed
 
-####**IsCutTrees ()**
+#### **IsCutTrees ()**
   Returns whether this unit is currently set to automatically cut trees it collides with.  Default is false
 
-####**IsFollowNavMesh ()**
+#### **IsFollowNavMesh ()**
   Returns whether this unit will respect the navigation mesh when moving the unit around.
 
-####**IsHibernate ()**
+#### **IsHibernate ()**
   Returns whether this unit should hibernate when there are no physics calculations to be performed
 
-####**IsInSimulation ()**
+#### **IsInSimulation ()**
   Returns whether this unit is currently in an active physics simulation or not.
 
-####**IsLockToGround ()**
+#### **IsLockToGround ()**
   Returns whether this unit will lock the unit to the ground while performing position calculations. 
 
-####**IsPreventDI ()**
+#### **IsPreventDI ()**
   Returns whether this unit will be prevented from influencing the direction of the physics calculations.
 
-####**IsSlide ()**
+#### **IsSlide ()**
   Returns whether this unit is currently sliding
 
-####**OnBounce (function(unit, normal))**
+#### **OnBounce (function(unit, normal))**
   Set the callback function to be executed when a PHYSICS_NAV_BOUNCE is occuring, but after the velocity rebound calculation has been performed and applied.  The function passed in has two parameters given to it, the unit in question and the normal vector of the surface that the unit is bouncing off of.
 
-####**OnPreBounce (function(unit, normal))**
+#### **OnPreBounce (function(unit, normal))**
   Set the callback function to be executed when a PHYSICS_NAV_BOUNCE is occuring, but before the velocity rebound calculation has been performed and applied.  The function passed in has two parameters given to it, the unit in question and the normal vector of the surface that the unit is bouncing off of.
 
-####**OnHibernate (function(unit))**
+#### **OnHibernate (function(unit))**
   Set the callback function (with one parameter, the unit in question) to be executed in the event that this unit begins hibernating.
 
-####**OnSlide (function(unit, normal))**
+#### **OnSlide (function(unit, normal))**
   Set the callback function to be executed when a PHYSICS_NAV_SLIDE is occuring, but after the velocity direction nullification has been performed and applied.  The function passed in has two parameters given to it, the unit in question and the normal vector of the surface that the unit is sliding off of.
 
-####**OnPreSlide (function(unit, normal))**
+#### **OnPreSlide (function(unit, normal))**
   Set the callback function to be executed when a PHYSICS_NAV_SLIDE is occuring, but before the velocity direction nullification has been performed and applied.  The function passed in has two parameters given to it, the unit in question and the normal vector of the surface that the unit is sliding off of.
 
-####**OnPhysicsFrame (function(unit))**
+#### **OnPhysicsFrame (function(unit))**
   Set the callback function (with one parameter, the unit in question) to be executed every frame for this unit so long as it is not hibernating. You can use this function to do additional calculations/collision detection/velocity modification.
 
-####**PreventDI (boolean)**
+#### **PreventDI (boolean)**
   Whether to prevent this unit from influencing the direction of the simulation.  The default is false
 
-####**SetAutoUnstuck (boolean)**
+#### **SetAutoUnstuck (boolean)**
   Whether to return this unit to its last known good position in the event that the library determines them to be "stuck" for enough frames in an unpathable area.  Default is true.
 
-####**SetBounceMultiplier (bounceMultipler)**
+#### **SetBounceMultiplier (bounceMultipler)**
   Sets the magnitude to adjust the velocity of a unit in the event of a PHYSICS_NAV_BOUNCE bounce.  .5 would halve the total velocity of the unit, while 2.0 would double it on bounce. Default is 1.0. 
 
-####**SetBoundOverride (bound)**
+#### **SetBoundOverride (bound)**
   Sets the current boundary radius override for this unit, which will be used when blocking the unit out from navigation grid collisions so that it doesn't get stuck.
 
-####**SetGroundBehavior (groundBehavior)**
+#### **SetGroundBehavior (groundBehavior)**
 
  - PHYSICS_GROUND_NOTHING: The unit will be able to pass through terrain and will not change its z-coordinate in any way concerning terrain
  - PHYSICS_GROUND_ABOVE: The unit will follow the ground so long as the ground is "above" the unit.  If the unit is above the ground, it will not lock to the ground.
  - PHYSICS_GROUND_LOCK: The unit will remain attached to the ground regardless of z-coordinate position/velocity/acceleration
 
-####**SetNavCollisionType (navCollisionType)**
+#### **SetNavCollisionType (navCollisionType)**
   Sets the behavior that the physics system will use when this unit collides with the GridNav mesh.  Possibilities are PHYSICS_NAV_NOTHING, PHYSICS_NAV_HALT, PHYSICS_NAV_SLIDE, or PHYSICS_NAV_BOUNCE.  Default is PHYSICS_NAV_SLIDE
   
  - PHYSICS_NAV_NOTHING: The unit will continue normal velocity/position calculations, potentially bumping up against the nav mesh multiple times
@@ -180,55 +180,55 @@ See [CollidersReadme.md](https://github.com/bmddota/barebones/blob/source2/Colli
  - PHYSICS_NAV_BOUNCE: The unit will bounce off of the GridNav mesh face it contacts with, continuing on in a different direction with the same velocity magnitude
  - PHYSICS_NAV_GROUND: The unit will travel along the ground based on the slope of the terrain, ignoring the GNV entirely.  If the slope of the terrain exceeds the slope limit set with SetNavGroundAngle, then the unit will slide down the terrain.
 
-####**SetNavGridLookahead (lookaheadPoints)**
+#### **SetNavGridLookahead (lookaheadPoints)**
   Sets the number of navigation grid lookahead points to use when determining a navigation grid collision for PHYSICS_NAV_HALT/NOTHING/SLIDE/BOUCE.  The physics system will lookahead to the 1..lookaheadPoints-1 / lookaheadPoints the distance to the next position in order to determine if the unit will pass into an unwalkable location during the next frame. Increasing this number allows for higher speed collisions with the navigation grid and helps to prevent units from slipping through the grid by using speed.  Default is 1.  Note: This adds a lot of calculations even at 3 or 4, so be careful with this value for performance reasons.
 
-####**SetNavGroundAngle (angle)**
+#### **SetNavGroundAngle (angle)**
   Sets the current terrain angle that will cause PHYSICS_NAV_GROUND based navigation to slide.
 
-####**SetPhysicsAcceleration (accelerationVector)**
+#### **SetPhysicsAcceleration (accelerationVector)**
   Sets the internal acceleration vector to the given vector, eliminating any existing acceleration
 
-####**SetPhysicsBoundingRadius (boundingRadius)**
+#### **SetPhysicsBoundingRadius (boundingRadius)**
   Sets the internal bounding radius used for navgrid collision.
 
-####**SetPhysicsFlatFriction (flatFriction)**
+#### **SetPhysicsFlatFriction (flatFriction)**
   Sets the flat friction amount.  The default is 0.
 
-####**SetPhysicsFriction (frictionMultiplier[, flatFriction])**
+#### **SetPhysicsFriction (frictionMultiplier[, flatFriction])**
   Sets the friction multiplier and/or flat friction amount.  The default is .05 and 0.  Not providing flatFriction will keep the current value.
 
-####**SetPhysicsVelocity (velocityVector)**
+#### **SetPhysicsVelocity (velocityVector)**
   Sets the internal velocity vector to the given vector, eliminating any existing velocity
 
-####**SetPhysicsVelocityMax (maxVelocity)**
+#### **SetPhysicsVelocityMax (maxVelocity)**
   Sets the maximum velocity that the unit will clamp to during the simulation.  Default is 0, which in unlimited
 
-####**SetRebounceFrames (rebounceFrames)**
+#### **SetRebounceFrames (rebounceFrames)**
   Sets the number of frames to wait between PHYSICS_NAV_BOUNCE gridnav collisions before allowing for another collision to take place.  Default is 5 (aka 1/6 of a second)
 
-####**SetSlideMultiplier (slideMultiplier)**
+#### **SetSlideMultiplier (slideMultiplier)**
   Sets the slide multiplier.  The default is 0.1
 
-####**SetStaticVelocity (name, velocityVector)**
+#### **SetStaticVelocity (name, velocityVector)**
   Sets the internal static velocity vector to the given vector for this named static velocity vector, eliminating any existing static velocity for this named vector
 
-####**SetStuckTimeout (stuckFrames)**
+#### **SetStuckTimeout (stuckFrames)**
   Sets the number of frames to wait before determining that the player is "stuck" in an unpathable area before returning them via AutoUnstuck to their last known good position.  The default is 3 frames (aka .1 seconds).
 
-####**SetVelocityClamp (clamp)**
+#### **SetVelocityClamp (clamp)**
   Sets the velocity magnitude clamp for stopping physics calculations/hibernating.  The default is 20 hammer units per second
 
-####**SkipSlide (frames)**
+#### **SkipSlide (frames)**
   Sets the number of frames for which to skip the slide calculation for this unit.  This is useful when you need to reposition a unit (respawn/blink/etc) but don'target want the Physics library slide calculation to add in a massive sliding velocity due to that teleport.  In the same frame as the respawn/blink you should issue a  unit:SkipSlide(2).  Slide calculations will resume when all SkipSlide frames are counted out.
 
-####**Slide (boolean)**
+#### **Slide (boolean)**
   Whether this unit should be sliding or not.  Sliding units accelerate based on their direction of travel in addition to their normal movespeed motion.
 
-####**StartPhysicsSimulation ()**
+#### **StartPhysicsSimulation ()**
   Restart the physics simulation if it has been stopped by StopPhysicsSimulation
 
-####**StopPhysicsSimulation ()**
+#### **StopPhysicsSimulation ()**
   Stop the physics simulation from executing any more for this unit
   
   

--- a/ProjectilesReadme.md
+++ b/ProjectilesReadme.md
@@ -1,11 +1,11 @@
-#**BMD's Lua Advanced Projectiles Library**
+# **BMD's Lua Advanced Projectiles Library**
 --------------------------------
 
-####**How to install:**
+#### **How to install:**
 - Drop projectiles.lua in with your vscripts
 - Add require( 'projectiles' ) somewhere in your lua instantiation path
 
-####**How to use:**
+#### **How to use:**
 - The projectiles library can be used to generate projectiles which are a combination of mathematical simulation and particle control.
 - Projectiles.lua projectiles do not use a unit or entity as part of the projectile simulation, and as such are lighter weight than unit-based projectiles.
 - Due to not using a unit, the projectile simulation can potentially get out of synch with the particle representation if there a large number of high-velocity changes.  Because of this, a projectile which needs highly complex motion is better off implemented as a Physics:Unit().
@@ -14,14 +14,14 @@
 
 **Projectiles Library Functions**
 =============================
-####**Projectiles:CreateProjectile(projectile)**
+#### **Projectiles:CreateProjectile(projectile)**
   This function is used to create ane release the projectile defined by the projectile table passed to the function.  The function returns an updated reference to the projectile table on which the Proejctile Table Functions can be called.  See the Projectiles Table Format section for more detail on what properties can be used with the projectile table.
 
 
-####**Projectiles:CalcSlope(pos, unit, dir)**
+#### **Projectiles:CalcSlope(pos, unit, dir)**
   This function can be used to get the estimated slope of the ground in the given Vector direction 'dir' at the world point Vector 'pos'.  The 'unit' parameter is used to specify what unit should be used with GetGroundPosition() in order to handle the ground collision sizing.  This function can return odd values when used around sheer vertical edges.
 
-####**Projectiles:CalcNormal(pos, unit, scale)**
+#### **Projectiles:CalcNormal(pos, unit, scale)**
   This function can be used to get the estimated normal Vector of the ground at the world point Vector 'pos'.  The 'unit' parameter is used to specify what unit should be used with GetGroundPosition() in order to handle the ground collision sizing.  This function can return odd values when used around sheer vertical edges.
 
 
@@ -29,22 +29,22 @@
 =============================
 A projectile table which has been fed to CreateProjectile will have the following functions:
 
-####**projectile:GetVelocity()**
+#### **projectile:GetVelocity()**
   This function can be called to get the current velocity vector of this projectile.
 
-####**projectile:Destroy()**
+#### **projectile:Destroy()**
   This function can be called to immediately destroy this projectile, triggering its OnFinish callback function if present.
 
-####**projectile:SetVelocity(newVel[, newPos])**
+#### **projectile:SetVelocity(newVel[, newPos])**
   This function can be called to adjust the current velocity of the projectile, as well as the current simulated position of the unit (if specified).  The projectile simulation and particle will only update if the projectile is within its nMaxChanges velocity change limit.
 
-####**projectile:GetCreationTime()**
+#### **projectile:GetCreationTime()**
   This function reutnrs the creation time in GameTime of this projectile.
 
-####**projectile:GetDistanceTraveled()**
+#### **projectile:GetDistanceTraveled()**
   This function returns the total distance traveled by this projectile in hammer units per second.  Only counts distance moved due to velocity and not by setting a new position with SetVelocity.
 
-####**projectile:GetPosition()**
+#### **projectile:GetPosition()**
   This function returns the current world position of the projectile.
 
 

--- a/README.md
+++ b/README.md
@@ -12,87 +12,87 @@ Barebones divides scripts up into several sections: Core Files, Libraries, Examp
 ## Installation
 Barebones can be installed by downloading this git repository and ensuring that you merge the "content" and "game" folder from this repo with your own "content" and "game" folders.  These should be located in your "<SteamLibraryDirectory>\SteamApps\common\dota 2 beta\" folder.  **Be sure you don't use the "dota_ugc" folder!**
 
-##Core Files
+## Core Files
 Core Files are the primary files which you should modify in order to get your basic game mode up and running.  There are 4 major files:
 
-####settings.lua
+#### settings.lua
 This file contains many special settings/properties created for barebones that allows you to define the high-level behavior of your game mode.
 You can define things like respawn times, number of teams on the map, rune spawn times, etc.  Each property is commented to help you understand it.
 
-####gamemode.lua
+#### gamemode.lua
 This is the primary barebones gamemode script and should be used to assist in initializing your game mode.
 This file contains helpful pseudo-event functions prepared for you for frequently needed initialization actions.
 
-####events.lua
+#### events.lua
 This file contains a hooked version of almost every event that is currently known to fire in the DotA 2 Lua vscript code.
 You can drop your event handler functions in there to have your game mode react to events.
 
-####addon_game_mode.lua
+#### addon_game_mode.lua
 This is the entry-point to your game mode and should be used primarily to precache models/particles/sounds/etc.
 
-##Libraries
+## Libraries
 I've included some helpful libraries with barebones that may prove useful in your game mode.
 
-####timers.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/TimersChangeLog.md)
+#### timers.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/TimersChangeLog.md)
 This library allow for easily delayed/timed actions without the messiness of thinkers and dealing with pauses.
 
-####physics.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/PhysicsChangeLog.md)
+#### physics.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/PhysicsChangeLog.md)
 This library can be used for advancted physics/motion/collision of units.  
 See [PhysicsReadme.md](https://github.com/bmddota/barebones/blob/source2/PhysicsReadme.md) and [CollidersReadme.md](https://github.com/bmddota/barebones/blob/source2/CollidersReadme.md) for more information.
 
-####projectiles.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/ProjectilesChangeLog.md)
+#### projectiles.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/ProjectilesChangeLog.md)
 This library can be used for advanced 3D projectile systems.  
 See [ProjectilesReadme.md](https://github.com/bmddota/barebones/blob/source2/ProjectilesReadme.md) for more information.
 
-####notifications.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/NotificationsChangeLog.md)
+#### notifications.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/NotificationsChangeLog.md)
 This library can be used to send panorama notifications to individuals/teams/everyone in your game.  
 See [libraries/notifications.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/notifications.lua) for usage details and examples.
 
-####animations.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/AnimationsChangeLog.md)
+#### animations.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/AnimationsChangeLog.md)
 This library can be used to start animations with customized animation rates, activities, and translations.  
 See [libraries/animations.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/animations.lua) for usage details and examples.
 
-####attachments.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/AttachmentsChangeLog.md)
+#### attachments.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/AttachmentsChangeLog.md)
 This library can be used to set up and put in place 'Frankenstein' attachments for attaching props to units.  
 See [libraries/attachments.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/attachments.lua) for usage details and examples.
 
-####playertables.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/PlayerTablesChangeLog.md)
+#### playertables.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/PlayerTablesChangeLog.md)
 This library sets up tables that are shared between server (lua) and client (javascript) between specific (but changeable) clients.  Similar to nettables.
 See [libraries/playertables.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/playertables.lua) for usage details and examples.  
 
-####containers.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/ContainersChangeLog.md)
+#### containers.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/ContainersChangeLog.md)
 This library allows for additional inventory/item containing objects and shops to be used in your game mode.
 See [libraries/containers.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/containers.lua) for usage details.  
 See [examples/playground.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/examples/playground.lua) for detailed examples.
 
-####worldpanels.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/WorldPanelsChangeLog.md)
+#### worldpanels.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/WorldPanelsChangeLog.md)
 This library allows for creating panorama layout panels that track the world position of an entity (or fixed world coordinate).
 See [libraries/worldpanels.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/worldpanels.lua) for usage details and examples.  
 
-####selection.lua  [By Noya](https://github.com/MNoya)
+#### selection.lua  [By Noya](https://github.com/MNoya)
 This library allows for querying and managing the selection status of players from the server-side lua script.  It also allows for automatic redirection and selection event handling.
 See [libraries/selection.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/selection.lua) for usage details and examples.  
 
-####pathgraph.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/PathGraphChangeLog.md)
+#### pathgraph.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/PathGraphChangeLog.md)
 This library constructs a full-edge graph of all "path_corner" objects, allowing for the use of the path links via lua script.
 See [libraries/pathgraph.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/pathgraph.lua) for usage details and examples.  
 
-####modmaker.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/ModmakerChangeLog.md)
+#### modmaker.lua  [Change Log](https://github.com/bmddota/barebones/blob/source2/ModmakerChangeLog.md)
 This library offers a searchable version of the lua server vscript API through the "modmaker_api" console command (in tools mode)
 See [libraries/modmaker.lua](https://github.com/bmddota/barebones/blob/source2/game/dota_addons/barebones/scripts/vscripts/libraries/modmaker.lua) for usage details and examples.  
 
 
 
-##Internals
+## Internals
 Barebones uses a few internal lua files in order to put together and handle the properties and pseudo-events systems.  You will likely not have to adjust these files at all.
 These files are found in the internal directory.
 
-##Debugging
+## Debugging
 Barebones now only prints out (spams) debugging information when told to by setting the BAREBONES_DEBUG_SPEW value in gamemode.lua to true.
 Previously there was a 'barebones_spew' cvar that could be used to change the debug printing state at any time from the console, but Valve broke RegisterConvar for some reason, so this has been disabled.
 
 
-##Additional Information
+## Additional Information
 - Barebones also comes with a sample loading screen implementation in panorama which you can view and edit via the content panorama directory.
 - You can change the name of the multiteams used at the Game Setup screen by editing the game/barebones/panorama/localization/addon_english.txt file.
 - You can adjust the number of players allowed on each of your maps by editing addoninfo.txt.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
